### PR TITLE
Limit connection on fetch and sync operations.

### DIFF
--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -13,6 +13,7 @@ class Fetch {
     this.table = opts.table
     this.saveLocation = path.resolve(process.cwd(), config.saveLocation)
     this.fileDownloader = new FileDownloader(logger)
+    this.maxConnections = config.maxConnections || 200
   }
   getNewest(files) {
     let toDownload = []
@@ -49,7 +50,7 @@ class Fetch {
         let toDownload = this.getNewest(files)
         this.logger.info(`Files (${toDownload.length})`, toDownload)
 
-        async.map(toDownload, (file, innerCb) => {
+        async.mapLimit(toDownload, this.maxConnections, (file, innerCb) => {
           this.fileDownloader.downloadToFile(
             file,
             {tableName: this.table, sequence: file.sequence},

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -5,8 +5,6 @@ var FileDownloader = require('./FileDownloader')
 var async = require('async')
 var mkdirp = require('mkdirp')
 var glob = require('glob')
-const DEFAULT_LIMIT = 50
-const CONCURRENCY_LIMIT = 5
 class Sync {
   constructor(opts, config, logger) {
     this.opts = opts
@@ -14,13 +12,14 @@ class Sync {
     this.api = new Api(config)
     this.fileDownloader = new FileDownloader(logger)
     this.saveLocation = path.resolve(process.cwd(), config.saveLocation)
+    this.maxConnections = config.maxConnections || 200
   }
   run(cb) {
     this.getSync((err, toSync) => {
       if (err) return cb(err)
       this.downloadSchema(toSync.schemaVersion, (err) => {
         if (err) return cb(err)
-        async.mapLimit(toSync.files, CONCURRENCY_LIMIT, this.processFile.bind(this), (err, results) => {
+        async.mapLimit(toSync.files, this.maxConnections, this.processFile.bind(this), (err, results) => {
           if (err) return cb(err)
 
           var splitResults = this.splitResults(results)


### PR DESCRIPTION
## Motivation (required) ##

This updates the fetch and sync operations to also use maxConnections config option when downloading files.

## Test Plan (required) ##

Limit the number of `maxConnection` in configuration file to 1. Attempt to fetch the requests files:

    canvasDataCli -l debug fetch -c config.js -t requests

Check that it it finishes downloading the first file before starting on the next one.
