### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ On subsequent executions, this will redownload all the data for that table, igno
 This command will unpack the gzipped files, concat any partitioned files, and add a header to the output file
 
 ```Shell
-canvasDataCli unpack -c path/to/config.js -f user_dim,account_dim
+canvasDataCli unpack -c path/to/config.js -f user_dim account_dim
 ```
 
 This command will unpack the user_dim and account_dim tables to a directory. Currently, you explictly have to give the files you want to unpack


### PR DESCRIPTION
the unpack example should be canvasDataCli unpack -c path/to/config.js -f user_dim account_dim.
The separator between multiple files is a space, not a commas as currently documented.

From issue:
https://github.com/instructure/canvas-data-cli/issues/26

Thanks for submitting a PR! We want to make contributing to the Canvas Data CLI as easy as possible.
Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [ ] Make sure to **add tests** to help keep code coverage up.

## Motivation (required) ##

What existing problem does the pull request solve?

The current unpack command example is wrong and does not work. Looking at the issues, the example in the readme does not align with the documentation. 

Updated the readme so the example works.

## Test Plan (required) ##

A good test plan has the exact commands you ran and their output.

If you have added code that should be tested, add tests.

## Next Steps ##

- Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.
- Make sure all **tests pass**, we will run this on jenkins but you can run it yourself with the `build.sh` script.
