### PR TITLE
Switch to `Buffer.from` as `new Buffer` deprecated

### DIFF
--- a/src/apiAuth.js
+++ b/src/apiAuth.js
@@ -26,7 +26,7 @@ var apiAuth = {
   },
   buildHmacSig: function(secret, timestamp, reqOpts) {
     var message = apiAuth.buildMessage(secret, timestamp, reqOpts)
-    var hmac = crypto.createHmac(HMAC_ALG, new Buffer(secret))
+    var hmac = crypto.createHmac(HMAC_ALG, Buffer.from(secret))
     hmac.update(message)
     return hmac.digest('base64')
   },


### PR DESCRIPTION
Since nodejs 6 `new Buffer(…)` has been deprecated and shouldn’t be used, this switches to the newer method and this gets rid of the warning.

Fixes #46

Thanks for submitting a PR! We want to make contributing to the Canvas Data CLI as easy as possible.
Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [ ] Make sure to **add tests** to help keep code coverage up.

## Motivation (required) ##

Fixes a warning

## Test Plan (required) ##

Check that the canvas-data-cli still works in making authenticated requests.

## Next Steps ##

- Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.
- Make sure all **tests pass**, we will run this on jenkins but you can run it yourself with the `build.sh` script.
